### PR TITLE
Ajout de la classe loaded à body

### DIFF
--- a/webdev/index.htm
+++ b/webdev/index.htm
@@ -7,7 +7,7 @@
 		<link rel="stylesheet" href="css/jeedom.css">
 		<title>Remora</title>
 	</head>
-	<body>
+	<body class="loaded">
 	  <div class="container">
 			<!--  Onglets  -->
 			<ul class="nav nav-tabs" id="myTab">


### PR DESCRIPTION
Salut Charles,

J'ai trouvé pourquoi cela plantait, j'avais oublié d'ajouter la classe CSS **loaded** sur la balise _body_ pour cacher le loader :-(
