### PR TITLE
Ajout de la fonction d'activation du délestage

### DIFF
--- a/remora.h
+++ b/remora.h
@@ -30,6 +30,7 @@
 //#define MOD_OLED      /* Afficheur  */
 #define MOD_TELEINFO  /* Teleinfo   */
 //#define MOD_RF_OREGON   /* Reception des sondes orégon */
+#define MOD_ADPS          /* Délestage */
 
 // Version logicielle remora
 #define REMORA_VERSION "1.3.2"

--- a/remora_soft.ino
+++ b/remora_soft.ino
@@ -657,6 +657,9 @@ void mysetup()
   #ifdef BLYNK_AUTH
     Serial.print("BLYNK ");
   #endif
+  #ifdef MOD_ADPS
+    Debug("ADPS ");
+  #endif
 
   Serial.println();
 

--- a/tinfo.cpp
+++ b/tinfo.cpp
@@ -223,7 +223,9 @@ bool tinfo_setup(bool wait_data)
   tinfo.init();
 
   // Attacher les callback donc nous avons besoin
-  tinfo.attachADPS(ADPSCallback);
+  #ifdef MOD_ADPS
+    tinfo.attachADPS(ADPSCallback);
+  #endif
   tinfo.attachData(DataCallback);
   tinfo.attachNewFrame(NewFrame);
   tinfo.attachUpdatedFrame(UpdatedFrame);
@@ -318,6 +320,7 @@ void tinfo_loop(void)
   #endif
 
   // Faut-il enclencher le delestage ?
+  #ifdef MOD_ADPS
   //On dépasse le courant max?
   if (fiInst > myDelestLimit) {
     if ((millis() - timerDelestRelest) > 5000L)  {
@@ -344,6 +347,7 @@ void tinfo_loop(void)
       }
     }
   }
+  #endif //ADPS active
 
   // Do we have RGB led timer expiration ?
   if (tinfo_led_timer && (millis()-tinfo_led_timer >= TINFO_LED_BLINK_MS)) {

--- a/webserver.cpp
+++ b/webserver.cpp
@@ -292,6 +292,9 @@ void getSysJSONData(String & response)
   #ifdef MOD_RF69
     response += F("RFM69 ");
   #endif
+  #ifdef MOD_ADPS
+    response += F("ADPS");
+  #endif
   response += "\"},\r\n";
 
   response += "{\"na\":\"SDK Version\",\"va\":\"";
@@ -373,10 +376,14 @@ void getSysJSONData(String & response)
   response += "\"},\r\n";
 
   response += "{\"na\":\"Etat Delestage\",\"va\":\"";
-  response += "Niveau ";
-  response += String(nivDelest);
-  response += " Zone ";
-  response += String(plusAncienneZoneDelestee);
+  #ifdef MOD_ADPS
+    response += "Niveau ";
+    response += String(nivDelest);
+    response += " Zone ";
+    response += String(plusAncienneZoneDelestee);
+  #else
+    response += "désactivé";
+  #endif
   response += "\"},\r\n";
 
   // Free mem should be last one
@@ -722,10 +729,14 @@ Comments: -
 void delestageJSON(String & response)
 {
     response = FPSTR(FP_JSON_START);
-    response += FPSTR("\"niveau\": ");
-    response += String(nivDelest);
-    response += FPSTR(", \"zone\": ");
-    response += String(plusAncienneZoneDelestee);
+    #ifdef MOD_ADPS
+      response += FPSTR("\"niveau\": ");
+      response += String(nivDelest);
+      response += FPSTR(", \"zone\": ");
+      response += String(plusAncienneZoneDelestee);
+    #else
+      response += FPSTR("\"etat\": \"désactivé\"");
+    #endif
     response += FPSTR(FP_JSON_END);
 }
 


### PR DESCRIPTION
Salut Charles,

Voici le code permettant d'activer ou non la fonction de délestage. A défaut de terminer le développement des connexions asynchrones, je réalise quelques modifs intéressantes pour certains ;-)

Le fonctionnement est simple, tu (dé)commentes la ligne `#define MOD_ADPS` dans le fichier _remora.h_, comme pour la téléinfo. Ca désactive l'attachement de la fonction de callback et ça bloque la vérification de dépassement du délestage. L'information de désactivation est retournée dans les infos système et dans le retour JSON de l'état du délestage.

Manuel
