### PR TITLE
Correction init debug serial

### DIFF
--- a/remora.h
+++ b/remora.h
@@ -109,7 +109,8 @@ extern "C" {
 
   #define _yield  yield
   #define _wdt_feed ESP.wdtFeed
-  #define DEBUG_SERIAL  Serial1
+  #define DEBUG_SERIAL  Serial
+  //#define DEBUG_INIT          // Décommenter cette ligne si DEBUG_SERIAL est Serial1
 #endif
 
 #define DEBUG

--- a/remora_soft.ino
+++ b/remora_soft.ino
@@ -1,4 +1,4 @@
-  // **********************************************************************************
+// **********************************************************************************
 // Programmateur Fil Pilote et Suivi Conso
 // **********************************************************************************
 // Copyright (C) 2014 Thibault Ducret
@@ -354,7 +354,7 @@ void setup()
     waitUntil(Particle.connected);
 
   #endif
-  #ifdef DEBUG
+  #ifdef DEBUG_INIT
     DEBUG_SERIAL.begin(115200);
   #endif
 

--- a/remora_soft.ino
+++ b/remora_soft.ino
@@ -354,7 +354,7 @@ void setup()
     waitUntil(Particle.connected);
 
   #endif
-  #ifdef DEBUG_INIT
+  #if defined DEBUG_INIT || !defined MOD_TELEINFO
     DEBUG_SERIAL.begin(115200);
   #endif
 
@@ -444,8 +444,10 @@ void mysetup()
 
   #elif defined (ESP8266)
 
-    // Init de la téléinformation
-    Serial.begin(1200, SERIAL_7E1);
+    #ifdef MOD_TELEINFO
+      // Init de la téléinformation
+      Serial.begin(1200, SERIAL_7E1);
+    #endif
 
     // Clear our global flags
     config.config = 0;


### PR DESCRIPTION
Salut Charles,

Voici une correction concernant le debug, car j'initialisais la connexion à 115200 bauds, sans vérifier quel port série était définit sur DEBUG_SERIAL. J'ai donc créé une constante DEBUG_INIT qui doit être décommentée lorsque DEBUG_SERIAL est défini à `Serial1`.
Peut être as tu une astuce pour connaitre le port série défini ?

Manuel
