### PR TITLE
Ajout du display SSH1106

### DIFF
--- a/config.h
+++ b/config.h
@@ -134,8 +134,9 @@ typedef struct
   char  ota_auth[CFG_PSK_SIZE+1];  // OTA Authentication password
   uint32_t config;           		   // Bit field register
   uint16_t ota_port;         		   // OTA port
-  uint8_t led_bright;              // RGB Led brightness 252
-  uint8_t  filler[130];      		   // in case adding data in config avoiding loosing current conf by bad crc
+  uint8_t  led_bright;             // RGB Led brightness 0-255
+  uint16_t oled_type;              // Display OLED type (1306 or 1106)
+  uint8_t  filler[128];      		   // in case adding data in config avoiding loosing current conf by bad crc
   _emoncms emoncms;                // Emoncms configuration
   _jeedom  jeedom;                 // jeedom configuration
   uint8_t  filler1[256];           // Another filler in case we need more

--- a/display.h
+++ b/display.h
@@ -24,6 +24,7 @@
 #define SDA_PIN  4
 #define SDC_PIN  5
 
+#ifdef MOD_OLED
 // Variables exported for other source file
 // ========================================
 extern OLEDDisplay *display;
@@ -58,4 +59,5 @@ void displaySplash(bool _config_ok);
 void displayCommand(void);
 void displayTest(void);
 
+#endif
 #endif

--- a/i2c.cpp
+++ b/i2c.cpp
@@ -84,17 +84,24 @@ uint8_t i2c_scan()
     {
       DebugF("I2C device found at address 0x");
       if (address<16)
-        Debug("0");
+        DebugF("0");
       DEBUG_SERIAL.print(address, HEX);
 
       if (address>=0x20 && address<=0x27)
         Debugln("-> MCP23017 !");
-      else if (address==0x3C || address==0x3D)
-        Debugln("-> OLED !");
-      else if (address==0x29 || address==0x39 || address==0x49)
+      else if (address==0x3C || address==0x3D) {
+        DebugF("-> OLED ");
+        if (address==0x3C) {
+          config.oled_type = 1306;
+          DebuglnF("1306!");
+        } else if (address==0x3D) {
+          config.oled_type = 1106;
+          DebuglnF("1106!");
+        }
+      } else if (address==0x29 || address==0x39 || address==0x49)
         Debugln("-> TSL2561 !");
       else
-        Debugln("-> Unknown device !");
+        Debugf("-> Unknown device at 0x%02X!\n");
 
       nDevices++;
     }

--- a/i2c.h
+++ b/i2c.h
@@ -16,6 +16,7 @@
 #define I2C_h
 
 #include "remora.h"
+#include "display.h"
 
 #ifdef ESP8266
 #include <Wire.h>

--- a/remora.h
+++ b/remora.h
@@ -29,8 +29,8 @@
 
 //  Définir ici les modules utilisés sur la carte Remora
 //#define MOD_RF69      /* Module RF  */
-#define MOD_OLED      /* Afficheur  */
-//#define MOD_TELEINFO  /* Teleinfo   */
+//#define MOD_OLED      /* Afficheur  */
+#define MOD_TELEINFO  /* Teleinfo   */
 //#define MOD_RF_OREGON   /* Reception des sondes orégon */
 #define MOD_ADPS          /* Délestage */
 
@@ -39,7 +39,7 @@
 #define OLED_SSD1306
 
 // Version logicielle remora
-#define REMORA_VERSION "1.3.7"
+#define REMORA_VERSION "1.3.6"
 
 // Définir ici votre authentification blynk, cela
 // Activera automatiquement blynk http://blynk.cc
@@ -80,7 +80,7 @@
 
   #define _yield  yield
   #define _wdt_feed ESP.wdtFeed
-  #define DEBUG_SERIAL  Serial
+  #define DEBUG_SERIAL  Serial1
   //#define DEBUG_INIT            /* Permet d'initialiser la connexion série pour debug */
   #define REBOOT_DELAY    100     /* Delay for rebooting once reboot flag is set */
 
@@ -240,7 +240,7 @@ extern "C" {
 #elif defined (REMORA_BOARD_V13) || defined(REMORA_BOARD_V14)
   #define LED_PIN    8
   #define RELAIS_PIN 9
-  #define RELAIS_REVERSE // Decommenter pour inverser le relais (si problème de relais on au lieu de off)
+  //#define RELAIS_REVERSE // Decommenter pour inverser le relais (si problème de relais on au lieu de off)
 
   // Creation macro unique et indépendante du type de
   // carte pour le controle des I/O

--- a/remora.h
+++ b/remora.h
@@ -30,9 +30,13 @@
 //  Définir ici les modules utilisés sur la carte Remora
 //#define MOD_RF69      /* Module RF  */
 #define MOD_OLED      /* Afficheur  */
-#define MOD_TELEINFO  /* Teleinfo   */
+//#define MOD_TELEINFO  /* Teleinfo   */
 //#define MOD_RF_OREGON   /* Reception des sondes orégon */
 #define MOD_ADPS          /* Délestage */
+
+// Type of OLED
+#define OLED_SH1106
+#define OLED_SSD1306
 
 // Version logicielle remora
 #define REMORA_VERSION "1.3.7"
@@ -105,7 +109,14 @@
   #include <ArduinoOTA.h>
   #include <Wire.h>
   #include <SPI.h>
+  #if defined (OLED_SSD1306)
   #include <SSD1306Wire.h>
+  #include <OLEDDisplayUi.h>
+  #endif
+  #if defined (OLED_SH1106)
+  #include <SH1106Wire.h>
+  #include <OLEDDisplayUi.h>
+  #endif
   #include <OLEDDisplayUi.h>
 
 extern "C" {
@@ -150,11 +161,11 @@ extern "C" {
 // Includes du projets remora
 #include "config.h"
 #include "linked_list.h"
+#include "display.h"
 #include "i2c.h"
 #include "rfm.h"
 #include "./icons.h"
 #include "./fonts.h"
-#include "display.h"
 #include "pilotes.h"
 #include "tinfo.h"
 #include "webserver.h"

--- a/remora_soft.ino
+++ b/remora_soft.ino
@@ -56,8 +56,6 @@
   #include <Ticker.h>
   #include <NeoPixelBus.h>
   #include <BlynkSimpleEsp8266.h>
-  #include <SSD1306Wire.h>
-  #include <OLEDDisplayUi.h>
   #include "./LibMCP23017.h"
   #include "./LibULPNode_RF_Protocol.h"
   #include "./LibLibTeleinfo.h"
@@ -655,6 +653,7 @@ void mysetup()
 
   // Init bus I2C
   i2c_init();
+  i2c_scan();
 
   Debug("Remora Version ");
   Debugln(REMORA_VERSION);


### PR DESCRIPTION
Ajout de la prise en compte des afficheurs OLED SSH1106 1.3" en 128*64 sous l'adresse **0x3D**