### PR TITLE
Correction compilation MOD_OLED

### DIFF
--- a/display.cpp
+++ b/display.cpp
@@ -13,415 +13,419 @@
 //
 // All text above must be included in any redistribution.
 // **********************************************************************************
-#include "display.h"
+
+#include "./display.h"
 
 SSD1306Wire * ssd1306 = NULL; // for SSD1306 Instance
 SH1106Wire  * sh1106 = NULL;  // for SH1106 Instance
 OLEDDisplay * display = NULL; // Display will point on the OLED instance
 OLEDDisplayUi * ui = NULL;    // Display User Interface
 
-// this array keeps function pointers to all frames
-// frames are the single views that slide from right to left
-FrameCallback frames[] = {
-    drawFrameLogo,
-    drawFrameTinfo,
-    drawFrameWifi,
-    // Frame RF is activated if MOD_RF69 is defined
-    #ifdef MOD_RF69
-    drawFrameRF
-    #endif
-};
 
-/* ======================================================================
-Function: initDisplay
-Purpose : Initialise l'afficheur OLED
-Input   : -
-Output  : Etat de l'initialisation
-Comments: -
-====================================================================== */
-bool initDisplay(void) {
-  uint8_t oled_addr;
+#ifdef MOD_OLED
+  // this array keeps function pointers to all frames
+  // frames are the single views that slide from right to left
+  FrameCallback frames[] = {
+      drawFrameLogo,
+      drawFrameTinfo,
+      drawFrameWifi,
+      // Frame RF is activated if MOD_RF69 is defined
+      #ifdef MOD_RF69
+      drawFrameRF
+      #endif
+  };
 
-  // in case of dynamic change of OLED display
-  delete ui;
-  delete ssd1306;
-  delete sh1106;
-  ui  = NULL;
-  display = NULL;
-  ssd1306 = NULL;
-  sh1106 = NULL;
+  /* ======================================================================
+  Function: initDisplay
+  Purpose : Initialise l'afficheur OLED
+  Input   : -
+  Output  : Etat de l'initialisation
+  Comments: -
+  ====================================================================== */
+  bool initDisplay(void) {
+    uint8_t oled_addr;
 
-  DebugF("config & CFG_LCD ...");
-  // Clear display configuration to force init
-  // and OLED detection
-  config.config &= ~CFG_LCD;
+    // in case of dynamic change of OLED display
+    delete ui;
+    delete ssd1306;
+    delete sh1106;
+    ui  = NULL;
+    display = NULL;
+    ssd1306 = NULL;
+    sh1106 = NULL;
 
-  // default OLED I2C address (0x3C or 0x3D)
-  oled_addr = I2C_DISPLAY_ADDRESS;
+    DebugF("config & CFG_LCD ...");
+    // Clear display configuration to force init
+    // and OLED detection
+    config.config &= ~CFG_LCD;
 
-  // Scan I2C Bus to check for OLED
-  if (i2c_detect(oled_addr)) {
-    config.config |= CFG_LCD;
-    DebugF(" SSD1306");
-  } else if (i2c_detect(++oled_addr)) {
-    config.config |= CFG_LCD;
-    DebugF(" SH1106");
-  } else {
-    DebuglnF("\ni2c_scan not found display");
-  }
+    // default OLED I2C address (0x3C or 0x3D)
+    oled_addr = I2C_DISPLAY_ADDRESS;
 
-  if (config.config & CFG_LCD) {
-    DebuglnF(" ... Display found");
-
-    // Instantiate the display
-    if (config.oled_type == 1306) {
-      ssd1306 = new SSD1306Wire(oled_addr, SDA, SCL);
-      display = ssd1306;
-    } else if (config.oled_type == 1106) {
-      sh1106 = new SH1106Wire(oled_addr, SDA, SCL);
-      display = sh1106;
+    // Scan I2C Bus to check for OLED
+    if (i2c_detect(oled_addr)) {
+      config.config |= CFG_LCD;
+      DebugF(" SSD1306");
+    } else if (i2c_detect(++oled_addr)) {
+      config.config |= CFG_LCD;
+      DebugF(" SH1106");
+    } else {
+      DebuglnF("\ni2c_scan not found display");
     }
 
-    // We got all fine
-    if (display) {
-      // Instantiate the User Interface
-      ui = new OLEDDisplayUi( display );
+    if (config.config & CFG_LCD) {
+      DebuglnF(" ... Display found");
 
-      // initialize display
-      display->init();
-      //display->flipScreenVertically();
+      // Instantiate the display
+      if (config.oled_type == 1306) {
+        ssd1306 = new SSD1306Wire(oled_addr, SDA, SCL);
+        display = ssd1306;
+      } else if (config.oled_type == 1106) {
+        sh1106 = new SH1106Wire(oled_addr, SDA, SCL);
+        display = sh1106;
+      }
+
+      // We got all fine
+      if (display) {
+        // Instantiate the User Interface
+        ui = new OLEDDisplayUi( display );
+
+        // initialize display
+        display->init();
+        //display->flipScreenVertically();
+        display->clear();
+        // Display CH2I Logo
+        display->drawXbm((128-ch2i_width)/2, 0, ch2i_width, ch2i_height, ch2i_bits);
+        display->display();
+
+        display->setFont(ArialMT_Plain_10);
+        display->setTextAlignment(TEXT_ALIGN_CENTER);
+        display->setContrast(255);
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /* ======================================================================
+  Function: initDisplayUI
+  Purpose : Initialise la bibliothèque UI pour les frames
+  Input   : -
+  Output  : -
+  Comments: -
+  ====================================================================== */
+  void initDisplayUI(void) {
+    if ( display && (config.config & CFG_LCD) ) {
+      ui->setTargetFPS(DISPLAY_FPS);
+      ui->setFrameAnimation(SLIDE_LEFT);
+      ui->setFrames(frames, DISPLAY_FRAME_COUNT);
+      ui->disableAllIndicators();
+      ui->init();
+      if (config.config & CFG_FLIP_LCD) {
+        //display->flipScreenVertically();
+      }
+    }
+  }
+
+  /* ======================================================================
+  Function: drawProgress
+  Purpose : Permet de créer une barre de progression avec un texte
+            au dessus et en dessous de la barre de progression
+  Input   : Pointeur sur l'instance de l'afficheur
+            Pourcentage de la progression
+            Titre au dessus de la barre de progression
+            Titre en dessous de la barre de progression
+  Output  : -
+  Comments: -
+  ====================================================================== */
+  void drawProgress(OLEDDisplay *display, int percentage, String labeltop, String labelbot) {
+    if (config.config & CFG_LCD) {
       display->clear();
-      // Display CH2I Logo
-      display->drawXbm((128-ch2i_width)/2, 0, ch2i_width, ch2i_height, ch2i_bits);
-      display->display();
-
-      display->setFont(ArialMT_Plain_10);
       display->setTextAlignment(TEXT_ALIGN_CENTER);
-      display->setContrast(255);
-      return true;
+      display->setFont(Roboto_Condensed_Bold_Bold_16);
+      display->drawString(64, 8, labeltop);
+      display->drawProgressBar(10, 28, 108, 12, percentage);
+      display->drawString(64, 48, labelbot);
+      display->display();
     }
   }
 
-  return false;
-}
-
-/* ======================================================================
-Function: initDisplayUI
-Purpose : Initialise la bibliothèque UI pour les frames
-Input   : -
-Output  : -
-Comments: -
-====================================================================== */
-void initDisplayUI(void) {
-  if ( display && (config.config & CFG_LCD) ) {
-    ui->setTargetFPS(DISPLAY_FPS);
-    ui->setFrameAnimation(SLIDE_LEFT);
-    ui->setFrames(frames, DISPLAY_FRAME_COUNT);
-    ui->disableAllIndicators();
-    ui->init();
-    if (config.config & CFG_FLIP_LCD) {
-      //display->flipScreenVertically();
+  /* ======================================================================
+  Function: drawProgress
+  Purpose : Permet de créer une barre de progression avec un texte
+            au dessus de la barre de progression
+  Input   : Pointeur sur l'instance de l'afficheur
+            Pourcentage de la progression
+            Titre au dessus de la barre de progression
+  Output  : -
+  Comments: -
+  ====================================================================== */
+  void drawProgress(OLEDDisplay *display, int percentage, String labeltop ) {
+    if (config.config & CFG_LCD) {
+      drawProgress(display, percentage, labeltop, String(""));
     }
   }
-}
 
-/* ======================================================================
-Function: drawProgress
-Purpose : Permet de créer une barre de progression avec un texte
-          au dessus et en dessous de la barre de progression
-Input   : Pointeur sur l'instance de l'afficheur
-          Pourcentage de la progression
-          Titre au dessus de la barre de progression
-          Titre en dessous de la barre de progression
-Output  : -
-Comments: -
-====================================================================== */
-void drawProgress(OLEDDisplay *display, int percentage, String labeltop, String labelbot) {
-  if (config.config & CFG_LCD) {
+  /* ======================================================================
+  Function: drawFrameWifi
+  Purpose : Fonction d'affichage de l'adresse IP de la Remora
+  Input   : Pointeur sur l'instance de l'afficheur
+            Etat de la frame
+            Coordonnées X
+            Coordonnées Y
+  Output  : -
+  Comments: -
+  ====================================================================== */
+  void drawFrameWifi(OLEDDisplay *display, OLEDDisplayUiState* state, int16_t x, int16_t y) {
     display->clear();
     display->setTextAlignment(TEXT_ALIGN_CENTER);
     display->setFont(Roboto_Condensed_Bold_Bold_16);
-    display->drawString(64, 8, labeltop);
-    display->drawProgressBar(10, 28, 108, 12, percentage);
-    display->drawString(64, 48, labelbot);
-    display->display();
+    // see http://blog.squix.org/2015/05/esp8266-nodemcu-how-to-create-xbm.html
+    // on how to create xbm files
+    display->drawXbm(x + (128-WiFi_width)/2, y, WiFi_width, WiFi_height, WiFi_bits);
+    display->drawString(x + 64, y + WiFi_height+4, WiFi.localIP().toString());
+    //ui->disableIndicator();
   }
-}
 
-/* ======================================================================
-Function: drawProgress
-Purpose : Permet de créer une barre de progression avec un texte
-          au dessus de la barre de progression
-Input   : Pointeur sur l'instance de l'afficheur
-          Pourcentage de la progression
-          Titre au dessus de la barre de progression
-Output  : -
-Comments: -
-====================================================================== */
-void drawProgress(OLEDDisplay *display, int percentage, String labeltop ) {
-  if (config.config & CFG_LCD) {
-    drawProgress(display, percentage, labeltop, String(""));
-  }
-}
+  /* ======================================================================
+  Function: drawProgressBarVert
+  Purpose : Fonction d'affichage d'une barre de progression verticale
+  Input   : Pointeur sur l'instance de l'afficheur
+            Coordonnées X du point haut de la barre
+            Coordonnées Y du point gauche de la barre
+            Largeur de la barre
+            Hauteur de la partie centrale de la barre
+            Pourcentage de la progression
+  Output  : -
+  Comments: -
+  ====================================================================== */
+  void drawProgressBarVert(OLEDDisplay *display, uint16_t x, uint16_t y, uint16_t width, uint16_t height, uint8_t progress) {
+    uint16_t radius = width >> 1;
+    uint16_t xRadius = x + radius;
+    uint16_t yRadius = y + radius;
+    uint16_t doubleRadius = 2 * radius;
+    uint16_t innerRadius = radius - 2;
 
-/* ======================================================================
-Function: drawFrameWifi
-Purpose : Fonction d'affichage de l'adresse IP de la Remora
-Input   : Pointeur sur l'instance de l'afficheur
-          Etat de la frame
-          Coordonnées X
-          Coordonnées Y
-Output  : -
-Comments: -
-====================================================================== */
-void drawFrameWifi(OLEDDisplay *display, OLEDDisplayUiState* state, int16_t x, int16_t y) {
-  display->clear();
-  display->setTextAlignment(TEXT_ALIGN_CENTER);
-  display->setFont(Roboto_Condensed_Bold_Bold_16);
-  // see http://blog.squix.org/2015/05/esp8266-nodemcu-how-to-create-xbm.html
-  // on how to create xbm files
-  display->drawXbm(x + (128-WiFi_width)/2, y, WiFi_width, WiFi_height, WiFi_bits);
-  display->drawString(x + 64, y + WiFi_height+4, WiFi.localIP().toString());
-  //ui->disableIndicator();
-}
+    display->setColor(WHITE);
+    display->drawCircleQuads(xRadius, yRadius, radius, 0b0000011);
+    display->drawVerticalLine(x, yRadius, height);
+    display->drawVerticalLine(x+width, yRadius, height);
+    display->drawCircleQuads(xRadius, yRadius+height-1, radius, 0b0001100);
 
-/* ======================================================================
-Function: drawProgressBarVert
-Purpose : Fonction d'affichage d'une barre de progression verticale
-Input   : Pointeur sur l'instance de l'afficheur
-          Coordonnées X du point haut de la barre
-          Coordonnées Y du point gauche de la barre
-          Largeur de la barre
-          Hauteur de la partie centrale de la barre
-          Pourcentage de la progression
-Output  : -
-Comments: -
-====================================================================== */
-void drawProgressBarVert(OLEDDisplay *display, uint16_t x, uint16_t y, uint16_t width, uint16_t height, uint8_t progress) {
-  uint16_t radius = width >> 1;
-  uint16_t xRadius = x + radius;
-  uint16_t yRadius = y + radius;
-  uint16_t doubleRadius = 2 * radius;
-  uint16_t innerRadius = radius - 2;
+    uint16_t maxProgress = ceil((progress * (height + doubleRadius)) / 100);
+    uint16_t maxProgressHeight = ceil((progress * height) / 100);
 
-  display->setColor(WHITE);
-  display->drawCircleQuads(xRadius, yRadius, radius, 0b0000011);
-  display->drawVerticalLine(x, yRadius, height);
-  display->drawVerticalLine(x+width, yRadius, height);
-  display->drawCircleQuads(xRadius, yRadius+height-1, radius, 0b0001100);
-
-  uint16_t maxProgress = ceil((progress * (height + doubleRadius)) / 100);
-  uint16_t maxProgressHeight = ceil((progress * height) / 100);
-
-  if (maxProgress > 0 && maxProgress <= radius) {
-    //                    120         46              5
-    display->fillCircle(xRadius, yRadius+height, radius-1);
-  }
-  else if (maxProgress > 0 && maxProgress <= height + radius) {
-    display->fillCircle(xRadius, yRadius+height, radius-1);
-    display->fillRect(x, (y  + height) - maxProgressHeight, width, maxProgressHeight);
-  }
-  else if (maxProgress > 0 && maxProgress <= height + doubleRadius) {
-    display->fillCircle(xRadius, yRadius+height, radius-1);
-    display->fillRect(x, (y  + height) - maxProgressHeight, width, maxProgressHeight);
-    display->fillCircle(xRadius, yRadius, radius-1);
-  }
-}
-
-/* ======================================================================
-Function: drawFrameTinfo
-Purpose : Fonction d'affichage de la téléinfo
-Input   : Pointeur sur l'instance de l'afficheur
-          Etat de la frame
-          Coordonnées X
-          Coordonnées Y
-Output  : -
-Comments: -
-====================================================================== */
-void drawFrameTinfo(OLEDDisplay *oled, OLEDDisplayUiState *state, int16_t x, int16_t y) {
-  uint8_t percent = 0;
-  char buff[20] = "";
-
-  oled->clear();
-  oled->setFont(Roboto_Condensed_Bold_Bold_16);
-
-  if (!(status & STATUS_TINFO)) {
-    oled->setTextAlignment(TEXT_ALIGN_CENTER);
-    oled->setColor(INVERSE);
-    oled->drawString(x + 64, 10, "Teleinfo");
-    oled->drawString(x + 64, 24, "not");
-    oled->drawString(x + 64, 38, "initialized");
-  }
-  else {
-    // Effacer le buffer de l'affichage
-    oled->setTextAlignment(TEXT_ALIGN_LEFT);
-    //oled->setFont(Roboto_Condensed_Bold_14);
-    oled->setFont(ArialMT_Plain_10);
-    oled->setColor(WHITE);
-
-    // si en heure pleine inverser le texte sur le compteur HP
-    //if (ptec == PTEC_HP )
-      //oled->setColor(BLACK); // 'inverted' text
-
-    //uint16_t lenLabel = oled->getStringWidth("Pleines ");
-    sprintf_P(buff, PSTR("Pleines %09ld"), myindexHP);
-    oled->drawString(x + 0, y + 0, buff);
-    //oled->setColor(WHITE); // normaltext
-
-    // si en heure creuse inverser le texte sur le compteur HC
-    //if (ptec == PTEC_HC )
-      //oled->setColor(INVERSE); // 'inverted' text
-
-    //oled->drawString(x + 0, 14 + y, "Creuses ");
-    memset(buff, 0, 20);
-    sprintf_P(buff, PSTR("Creuses %09ld"), myindexHC);
-    oled->drawString(x + 0, 14 + y, buff);
-    oled->setColor(WHITE); // normaltext
-
-    // Poucentrage de la puissance totale
-    percent = (uint) myiInst * 100 / myisousc;
-
-    //Serial.print("myiInst="); Serial.print(myiInst);
-    //Serial.print("  myisousc="); Serial.print(myisousc);
-    //Serial.print("  percent="); Serial.println(percent);
-
-    // Information additionelles
-    memset(buff, 0, 20);
-    sprintf_P(buff, PSTR("%d W %d%%  %3d A"), mypApp, percent, myiInst);
-    oled->drawString(x + 0, 28 + y, buff);
-
-    // etat des fils pilotes
-    // On transcrit l'état de fonctionnement du relais en une lettre
-    // S: arrêt, F: marche forcée, A: auto
-    char dFnctRelais = 'A';
-    if (fnctRelais == FNCT_RELAIS_ARRET) {
-      dFnctRelais = 'S';
-    } else if (fnctRelais == FNCT_RELAIS_FORCE) {
-      dFnctRelais = 'F';
+    if (maxProgress > 0 && maxProgress <= radius) {
+      //                    120         46              5
+      display->fillCircle(xRadius, yRadius+height, radius-1);
     }
-    memset(buff, 0, 20);
-    sprintf_P(buff, PSTR("%s %c%c"), etatFP, dFnctRelais, etatrelais+'0');
-    oled->drawString(x + 0, 48 + y, buff);
-
-    // Bargraphe de puissance
-    drawProgressBarVert(oled, 114, 6, 12, 40, percent);
-  }
-}
-
-/* ======================================================================
-Function: drawFrameLogo
-Purpose : Fonction d'affichage du logo de la Remora
-Input   : Pointeur sur l'instance de l'afficheur
-          Etat de la frame
-          Coordonnées X
-          Coordonnées Y
-Output  : -
-Comments: -
-====================================================================== */
-void drawFrameLogo(OLEDDisplay *display, OLEDDisplayUiState* state, int16_t x, int16_t y) {
-  display->clear();
-  display->drawXbm(x + (128-remora_width)/2, y, remora_width, remora_height, remora_bits);
-  //ui->disableIndicator();
-}
-
-/* ======================================================================
-Function: drawFrameRF
-Purpose : Fonction d'affichage des données radio
-Input   : Pointeur sur l'instance de l'afficheur
-          Etat de la frame
-          Coordonnées X
-          Coordonnées Y
-Output  : -
-Comments: -
-====================================================================== */
-void drawFrameRF(OLEDDisplay *display, OLEDDisplayUiState* state, int16_t x, int16_t y) {
-    char buff[32];
-    int16_t percent;
-    volatile uint8_t * p;
-    int8_t line = 0;
-    byte n;
-
-    n = rfData.size;
-    p = rfData.buffer;
-
-    display->clear();
-    display->setFont(Roboto_Condensed_Bold_Bold_16);
-
-    if (!(status & STATUS_RFM)) {
-      display->setTextAlignment(TEXT_ALIGN_CENTER);
-      display->drawString(x + 64, 10, "Radio");
-      display->drawString(x + 64, 24, "not");
-      display->drawString(x + 64, 38, "initialized");
+    else if (maxProgress > 0 && maxProgress <= height + radius) {
+      display->fillCircle(xRadius, yRadius+height, radius-1);
+      display->fillRect(x, (y  + height) - maxProgressHeight, width, maxProgressHeight);
     }
-    else if (!got_first) {
-      display->setTextAlignment(TEXT_ALIGN_CENTER);
-      display->drawString(x + 64, 14, "No radio data");
-      display->drawString(x + 64, 34, "received yet");
-    } else {
+    else if (maxProgress > 0 && maxProgress <= height + doubleRadius) {
+      display->fillCircle(xRadius, yRadius+height, radius-1);
+      display->fillRect(x, (y  + height) - maxProgressHeight, width, maxProgressHeight);
+      display->fillCircle(xRadius, yRadius, radius-1);
+    }
+  }
 
+  /* ======================================================================
+  Function: drawFrameTinfo
+  Purpose : Fonction d'affichage de la téléinfo
+  Input   : Pointeur sur l'instance de l'afficheur
+            Etat de la frame
+            Coordonnées X
+            Coordonnées Y
+  Output  : -
+  Comments: -
+  ====================================================================== */
+  void drawFrameTinfo(OLEDDisplay *oled, OLEDDisplayUiState *state, int16_t x, int16_t y) {
+    uint8_t percent = 0;
+    char buff[20] = "";
 
-      display->setTextAlignment(TEXT_ALIGN_LEFT);
-      if (rfData.type == RF_MOD_RFM69) {
-        sprintf_P(buff, PSTR("NODE %d"), rfData.nodeid );
-        display->drawString(x + 0, 0, buff);
+    oled->clear();
+    oled->setFont(Roboto_Condensed_Bold_Bold_16);
 
-        // rssi
-        percent = (int16_t) rfData.rssi;
+    if (!(status & STATUS_TINFO)) {
+      oled->setTextAlignment(TEXT_ALIGN_CENTER);
+      oled->setColor(INVERSE);
+      oled->drawString(x + 64, 10, "Teleinfo");
+      oled->drawString(x + 64, 24, "not");
+      oled->drawString(x + 64, 38, "initialized");
+    }
+    else {
+      // Effacer le buffer de l'affichage
+      oled->setTextAlignment(TEXT_ALIGN_LEFT);
+      //oled->setFont(Roboto_Condensed_Bold_14);
+      oled->setFont(ArialMT_Plain_10);
+      oled->setColor(WHITE);
 
-        // rssi for RFM69 is -115 (0%) to 0 (100%)
-  //      if (driver) {
-          // rssi range now 0 (0%) to 115 (100%)
-          percent += 115;
-          // now calc percentage
-          percent = (percent * 100) / 115;
-  //      }
+      // si en heure pleine inverser le texte sur le compteur HP
+      //if (ptec == PTEC_HP )
+        //oled->setColor(BLACK); // 'inverted' text
 
-        if (percent > 100) percent = 100;
-        if (percent < 0  ) percent = 0;
+      //uint16_t lenLabel = oled->getStringWidth("Pleines ");
+      sprintf_P(buff, PSTR("Pleines %09ld"), myindexHP);
+      oled->drawString(x + 0, y + 0, buff);
+      //oled->setColor(WHITE); // normaltext
 
-        // display bargraph on lcd
-        display->drawProgressBar( x + 62, 4, 64 , 12, percent);
+      // si en heure creuse inverser le texte sur le compteur HC
+      //if (ptec == PTEC_HC )
+        //oled->setColor(INVERSE); // 'inverted' text
 
-        //display->setFont(Roboto_Condensed_12);
-        display->setTextAlignment(TEXT_ALIGN_LEFT);
-        /*
-        line++; *buff='\0';
-        if (sensorData.temp != SENSOR_NOT_A_TEMP) {
-          sprintf_P(buff+strlen(buff), PSTR("%.1f°C  "), sensorData.temp/100.0f );
-        }
-        if (sensorData.bat != SENSOR_NOT_A_BAT) {
-          //sprintf_P(buff+strlen(buff), PSTR("%.2fV"), sensorData.bat/1000.0f );
-          display->drawXbm(x + 127 - bat_width, y + 20, bat_width, bat_height,
-                            sensorData.bat>1500?bat_100_bits:
-                            sensorData.bat>1400?bat_090_bits:
-                            sensorData.bat>1300?bat_080_bits:
-                            sensorData.bat>1200?bat_070_bits:
-                            sensorData.bat>1100?bat_060_bits:
-                            sensorData.bat>1000?bat_050_bits:
-                            sensorData.bat> 900?bat_040_bits:
-                            sensorData.bat> 800?bat_030_bits:
-                            sensorData.bat> 700?bat_020_bits:
-                            sensorData.bat> 600?bat_010_bits:bat_000_bits
-                            );
-        }
-        display->drawString(x + 0, y + line * 16, buff);
+      //oled->drawString(x + 0, 14 + y, "Creuses ");
+      memset(buff, 0, 20);
+      sprintf_P(buff, PSTR("Creuses %09ld"), myindexHC);
+      oled->drawString(x + 0, 14 + y, buff);
+      oled->setColor(WHITE); // normaltext
 
-        display->setTextAlignment(TEXT_ALIGN_CENTER);
-        line++; *buff='\0';
-        if (sensorData.lux != SENSOR_NOT_A_LUX) {
-          sprintf_P(buff+strlen(buff), PSTR("%.0f Lux  "), sensorData.lux/10.0f );
-        }
-        if (sensorData.hum != SENSOR_NOT_A_HUM) {
-          sprintf_P(buff+strlen(buff), PSTR("%.0f %%RH"), sensorData.hum/10.0f );
-        }*/
-        display->drawString(x + 64, y + line * 16, buff);
+      // Poucentrage de la puissance totale
+      percent = (uint) myiInst * 100 / myisousc;
 
-        display->setFont(Roboto_Condensed_12);
-        display->setTextAlignment(TEXT_ALIGN_CENTER);
-        display->drawString(x + 64, 48, timeAgo(uptime-packet_last_seen));
+      //Serial.print("myiInst="); Serial.print(myiInst);
+      //Serial.print("  myisousc="); Serial.print(myisousc);
+      //Serial.print("  percent="); Serial.println(percent);
+
+      // Information additionelles
+      memset(buff, 0, 20);
+      sprintf_P(buff, PSTR("%d W %d%%  %3d A"), mypApp, percent, myiInst);
+      oled->drawString(x + 0, 28 + y, buff);
+
+      // etat des fils pilotes
+      // On transcrit l'état de fonctionnement du relais en une lettre
+      // S: arrêt, F: marche forcée, A: auto
+      char dFnctRelais = 'A';
+      if (fnctRelais == FNCT_RELAIS_ARRET) {
+        dFnctRelais = 'S';
+      } else if (fnctRelais == FNCT_RELAIS_FORCE) {
+        dFnctRelais = 'F';
       }
-    }
-  //}
+      memset(buff, 0, 20);
+      sprintf_P(buff, PSTR("%s %c%c"), etatFP, dFnctRelais, etatrelais+'0');
+      oled->drawString(x + 0, 48 + y, buff);
 
-  //ui->disableIndicator();
-}
+      // Bargraphe de puissance
+      drawProgressBarVert(oled, 114, 6, 12, 40, percent);
+    }
+  }
+
+  /* ======================================================================
+  Function: drawFrameLogo
+  Purpose : Fonction d'affichage du logo de la Remora
+  Input   : Pointeur sur l'instance de l'afficheur
+            Etat de la frame
+            Coordonnées X
+            Coordonnées Y
+  Output  : -
+  Comments: -
+  ====================================================================== */
+  void drawFrameLogo(OLEDDisplay *display, OLEDDisplayUiState* state, int16_t x, int16_t y) {
+    display->clear();
+    display->drawXbm(x + (128-remora_width)/2, y, remora_width, remora_height, remora_bits);
+    //ui->disableIndicator();
+  }
+
+  /* ======================================================================
+  Function: drawFrameRF
+  Purpose : Fonction d'affichage des données radio
+  Input   : Pointeur sur l'instance de l'afficheur
+            Etat de la frame
+            Coordonnées X
+            Coordonnées Y
+  Output  : -
+  Comments: -
+  ====================================================================== */
+  void drawFrameRF(OLEDDisplay *display, OLEDDisplayUiState* state, int16_t x, int16_t y) {
+      char buff[32];
+      int16_t percent;
+      volatile uint8_t * p;
+      int8_t line = 0;
+      byte n;
+
+      n = rfData.size;
+      p = rfData.buffer;
+
+      display->clear();
+      display->setFont(Roboto_Condensed_Bold_Bold_16);
+
+      if (!(status & STATUS_RFM)) {
+        display->setTextAlignment(TEXT_ALIGN_CENTER);
+        display->drawString(x + 64, 10, "Radio");
+        display->drawString(x + 64, 24, "not");
+        display->drawString(x + 64, 38, "initialized");
+      }
+      else if (!got_first) {
+        display->setTextAlignment(TEXT_ALIGN_CENTER);
+        display->drawString(x + 64, 14, "No radio data");
+        display->drawString(x + 64, 34, "received yet");
+      } else {
+
+        display->setTextAlignment(TEXT_ALIGN_LEFT);
+        if (rfData.type == RF_MOD_RFM69) {
+          sprintf_P(buff, PSTR("NODE %d"), rfData.nodeid );
+          display->drawString(x + 0, 0, buff);
+
+          // rssi
+          percent = (int16_t) rfData.rssi;
+
+          // rssi for RFM69 is -115 (0%) to 0 (100%)
+    //      if (driver) {
+            // rssi range now 0 (0%) to 115 (100%)
+            percent += 115;
+            // now calc percentage
+            percent = (percent * 100) / 115;
+    //      }
+
+          if (percent > 100) percent = 100;
+          if (percent < 0  ) percent = 0;
+
+          // display bargraph on lcd
+          display->drawProgressBar( x + 62, 4, 64 , 12, percent);
+
+          //display->setFont(Roboto_Condensed_12);
+          display->setTextAlignment(TEXT_ALIGN_LEFT);
+          /*
+          line++; *buff='\0';
+          if (sensorData.temp != SENSOR_NOT_A_TEMP) {
+            sprintf_P(buff+strlen(buff), PSTR("%.1f°C  "), sensorData.temp/100.0f );
+          }
+          if (sensorData.bat != SENSOR_NOT_A_BAT) {
+            //sprintf_P(buff+strlen(buff), PSTR("%.2fV"), sensorData.bat/1000.0f );
+            display->drawXbm(x + 127 - bat_width, y + 20, bat_width, bat_height,
+                              sensorData.bat>1500?bat_100_bits:
+                              sensorData.bat>1400?bat_090_bits:
+                              sensorData.bat>1300?bat_080_bits:
+                              sensorData.bat>1200?bat_070_bits:
+                              sensorData.bat>1100?bat_060_bits:
+                              sensorData.bat>1000?bat_050_bits:
+                              sensorData.bat> 900?bat_040_bits:
+                              sensorData.bat> 800?bat_030_bits:
+                              sensorData.bat> 700?bat_020_bits:
+                              sensorData.bat> 600?bat_010_bits:bat_000_bits
+                              );
+          }
+          display->drawString(x + 0, y + line * 16, buff);
+
+          display->setTextAlignment(TEXT_ALIGN_CENTER);
+          line++; *buff='\0';
+          if (sensorData.lux != SENSOR_NOT_A_LUX) {
+            sprintf_P(buff+strlen(buff), PSTR("%.0f Lux  "), sensorData.lux/10.0f );
+          }
+          if (sensorData.hum != SENSOR_NOT_A_HUM) {
+            sprintf_P(buff+strlen(buff), PSTR("%.0f %%RH"), sensorData.hum/10.0f );
+          }*/
+          display->drawString(x + 64, y + line * 16, buff);
+
+          display->setFont(Roboto_Condensed_12);
+          display->setTextAlignment(TEXT_ALIGN_CENTER);
+          display->drawString(x + 64, 48, timeAgo(uptime-packet_last_seen));
+        }
+      }
+    //}
+
+    //ui->disableIndicator();
+  }
+
+#endif // #ifdef MOD_OLED

--- a/remora.h
+++ b/remora.h
@@ -156,21 +156,20 @@ extern "C" {
   #include "./LibRadioHead.h"
   #include "./LibRHReliableDatagram.h"
 
+  // Includes du projets remora
+  #include "./config.h"
+  #include "./linked_list.h"
+  #include "./display.h"
+  #include "./i2c.h"
+  #include "./rfm.h"
+  #include "./icons.h"
+  #include "./fonts.h"
+  #include "./pilotes.h"
+  #include "./tinfo.h"
+  #include "./webserver.h"
+  #include "./webclient.h"
+
 #endif
-
-// Includes du projets remora
-#include "config.h"
-#include "linked_list.h"
-#include "display.h"
-#include "i2c.h"
-#include "rfm.h"
-#include "./icons.h"
-#include "./fonts.h"
-#include "pilotes.h"
-#include "tinfo.h"
-#include "webserver.h"
-#include "webclient.h"
-
 
 // RGB LED related MACROS
 #if defined (SPARK)
@@ -240,7 +239,7 @@ extern "C" {
 #elif defined (REMORA_BOARD_V13) || defined(REMORA_BOARD_V14)
   #define LED_PIN    8
   #define RELAIS_PIN 9
-  //#define RELAIS_REVERSE // Decommenter pour inverser le relais (si problème de relais on au lieu de off)
+  #define RELAIS_REVERSE // Decommenter pour inverser le relais (si problème de relais on au lieu de off)
 
   // Creation macro unique et indépendante du type de
   // carte pour le controle des I/O

--- a/remora_soft.ino
+++ b/remora_soft.ino
@@ -55,6 +55,15 @@
   #include <SPI.h>
   #include <Ticker.h>
   #include <NeoPixelBus.h>
+  #if defined (OLED_SSD1306)
+  #include <SSD1306Wire.h>
+  #include <OLEDDisplayUi.h>
+  #endif
+  #if defined (OLED_SH1106)
+  #include <SH1106Wire.h>
+  #include <OLEDDisplayUi.h>
+  #endif
+  #include <OLEDDisplayUi.h>
   #include <BlynkSimpleEsp8266.h>
   #include "./LibMCP23017.h"
   #include "./LibULPNode_RF_Protocol.h"
@@ -525,6 +534,7 @@ void mysetup()
       LedRGBON(COLOR_MAGENTA);
       DebugF("\r\nUpdate Started..");
       // On affiche le début de la mise à jour OTA sur l'afficheur
+      #ifdef MOD_OLED
       if (status & STATUS_OLED) {
         ui->disableAutoTransition();
         display->clear();
@@ -533,6 +543,7 @@ void mysetup()
         display->drawString(DISPLAY_WIDTH/2, DISPLAY_HEIGHT/2 - 16, "OTA Update");
         display->display();
       }
+      #endif
       ota_blink = true;
     });
 
@@ -540,6 +551,7 @@ void mysetup()
       LedRGBOFF();
       DebuglnF("Update finished restarting");
       // On affiche le message de fin sur l'afficheur
+      #ifdef MOD_OLED
       if (status & STATUS_OLED) {
         ui->disableAutoTransition();
         display->clear();
@@ -548,6 +560,7 @@ void mysetup()
         display->drawString(DISPLAY_WIDTH/2, DISPLAY_HEIGHT/2 - 16, "Restart");
         display->display();
       }
+      #endif
     });
 
     ArduinoOTA.onProgress([](unsigned int progress, unsigned int total) {
@@ -558,6 +571,7 @@ void mysetup()
       }
       ota_blink = !ota_blink;
       // On affiche la progression sur l'afficheur
+      #ifdef MOD_OLED
       if (status & STATUS_OLED) {
         ui->disableAutoTransition();
         display->clear();
@@ -567,6 +581,7 @@ void mysetup()
         display->drawProgressBar(2, 28, 124, 10, progress / (total / 100));
         display->display();
       }
+      #endif
     });
 
     ArduinoOTA.onError([](ota_error_t error) {
@@ -586,6 +601,7 @@ void mysetup()
       Debugln(strErr);
 
       // On affiche l'erreur sur l'afficheur
+      #ifdef MOD_OLED
       if (status & STATUS_OLED) {
         ui->disableAutoTransition();
         display->clear();
@@ -596,6 +612,7 @@ void mysetup()
         display->drawString(DISPLAY_WIDTH/2, 30, strErr);
         display->display();
       }
+      #endif
       //reboot = true;
     });
 


### PR DESCRIPTION
Voici une correction pour un problème de compilation, sans le module OLED activé, lié aux dernières modifications de la gestion de l'affichage.