### PR TITLE
Usages de DEBUG_SERIAL remplacés par les bonnes fonctions de Debug

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -203,7 +203,7 @@ void showConfig()
   DebugF("key      :"); Debugln(config.jeedom.apikey);
   DebugF("finger   :");
   for (int i=0; i < CFG_JDOM_FINGER_PRINT_SIZE; i++) {
-    DEBUG_SERIAL.print(config.jeedom.fingerprint[i], HEX);
+    DebugIntFormat(config.jeedom.fingerprint[i], HEX);
     DebugF(" ");
   }
   Debugln();

--- a/i2c.cpp
+++ b/i2c.cpp
@@ -85,7 +85,7 @@ uint8_t i2c_scan()
       DebugF("I2C device found at address 0x");
       if (address<16)
         DebugF("0");
-      DEBUG_SERIAL.print(address, HEX);
+      DebugIntFormat(address, HEX);
 
       if (address>=0x20 && address<=0x27)
         Debugln("-> MCP23017 !");

--- a/linked_list.cpp
+++ b/linked_list.cpp
@@ -135,9 +135,9 @@ uint8_t ll_Dump(NodeList * me, unsigned long sec)
 
       index++;
       Debug(index);        DebugF(") ") ;
-      DebugF("Group:");   DEBUG_SERIAL.print(me->groupid, DEC) ;
-      DebugF("  Node:");  DEBUG_SERIAL.print(me->nodeid, DEC) ;
-      DebugF("  RSSI:");  DEBUG_SERIAL.print(me->rssi, DEC) ;
+      DebugF("Group:");   DebugIntFormat(me->groupid, DEC) ;
+      DebugF("  Node:");  DebugIntFormat(me->nodeid, DEC) ;
+      DebugF("  RSSI:");  DebugIntFormat(me->rssi, DEC) ;
       DebugF("  seen:");  Debug(sec-me->lastseen) ;
       DebuglnF("") ;
     }

--- a/remora.h
+++ b/remora.h
@@ -138,6 +138,9 @@ extern "C" {
 #define DebuglnF(x) DEBUG_SERIAL.println(F(x))
 #define Debugf(...) DEBUG_SERIAL.printf(__VA_ARGS__)
 #define Debugflush  DEBUG_SERIAL.flush
+#define DebugWiFi() WiFi.printDiag(DEBUG_SERIAL)
+#define DebugIntFormat(x,format) DEBUG_SERIAL.print(x, format)
+#define DebugUpdateError() Update.printError(DEBUG_SERIAL)
 #else
 #define Debug(x)
 #define Debugln(x)
@@ -145,6 +148,9 @@ extern "C" {
 #define DebuglnF(x)
 #define Debugf(...)
 #define Debugflush()
+#define DebugWiFi()
+#define DebugIntFormat(x,format)
+#define DebugUpdateError()
 #endif
 
 #ifdef ESP8266

--- a/remora_soft.ino
+++ b/remora_soft.ino
@@ -208,7 +208,7 @@ int WifiHandleConn(boolean setup = false)
     _wdt_feed();
 
     DebugF("========== SDK Saved parameters Start");
-    WiFi.printDiag(DEBUG_SERIAL);
+    DebugWiFi();
     DebuglnF("========== SDK Saved parameters End");
 
     #if defined (DEFAULT_WIFI_SSID) && defined (DEFAULT_WIFI_PASS)

--- a/rfm.cpp
+++ b/rfm.cpp
@@ -223,11 +223,11 @@ void rfm_loop(void)
         DebugF(" ACKED");
 
 
-      DebugF(" <- node:");  DEBUG_SERIAL.print(rfData.nodeid,DEC);
+      DebugF(" <- node:");  DebugIntFormat(rfData.nodeid,DEC);
       DebugF(" size:");     Debug(rfData.size);
-      DebugF(" type:");     DEBUG_SERIAL.print(decode_frame_type(cmd));
-      DebugF(" (0x");       DEBUG_SERIAL.print(cmd,HEX);
-      DebugF(") RSSI:");    DEBUG_SERIAL.print(rfData.rssi,DEC);
+      DebugF(" type:");     Debug(decode_frame_type(cmd));
+      DebugF(" (0x");       DebugIntFormat(cmd,HEX);
+      DebugF(") RSSI:");    DebugIntFormat(rfData.rssi,DEC);
       DebugF("dB  seen :");
       Debug(timeAgo(seen));
 
@@ -284,9 +284,9 @@ void rfm_loop(void)
      // Start line with a # (comment)
      // indicate external parser that it's just debug information
      DebugF("\r\n# -> ");
-     DEBUG_SERIAL.print(rfData.nodeid,DEC);
+     DebugIntFormat(rfData.nodeid,DEC);
      DebugF(" PINGBACK (");
-     DEBUG_SERIAL.print(ppl->rssi,DEC);
+     DebugIntFormat(ppl->rssi,DEC);
      DebuglnF("dB)");
    }
 

--- a/tinfo.cpp
+++ b/tinfo.cpp
@@ -88,7 +88,7 @@ void DataCallback(ValueList * me, uint8_t flags)
   Debug(me->value);
 
   //Debug(" Flags=0x");
-  //DEBUG_SERIAL.print(flags, HEX);
+  //DebugIntFormat(flags, HEX);
 
   if ( flags & TINFO_FLAGS_NOTHING ) DebugF(" Nothing");
   if ( flags & TINFO_FLAGS_ADDED )   DebugF(" Added");

--- a/webserver.cpp
+++ b/webserver.cpp
@@ -988,14 +988,14 @@ void handle_fw_upload(AsyncWebServerRequest *request, String filename, size_t in
       //DebuglnF("Command U_SPIFFS");
     }
     if (!Update.begin((ESP.getFreeSketchSpace() - 0x1000) & 0xFFFFF000, command)) {
-      Update.printError(DEBUG_SERIAL);
+      DebugUpdateError();
     }
   }
 
   if (!Update.hasError()) {
     if (Update.write(data, len) != len) {
       DebugF("*** UPDATE ERROR: ");
-      Update.printError(DEBUG_SERIAL);
+      DebugUpdateError();
       if (ota_blink) {
         LedRGBON(COLOR_RED);
       } else {
@@ -1018,7 +1018,7 @@ void handle_fw_upload(AsyncWebServerRequest *request, String filename, size_t in
     if (Update.end(true)) {
       Debugf("Update Success: %uB\n", index+len);
     } else {
-      Update.printError(DEBUG_SERIAL);
+      DebugUpdateError();
     }
     LedRGBOFF();
   }


### PR DESCRIPTION
Bonjour,

Je propose ici de remplacer les usages de l'objet **DEBUG_SERIAL** qui sont parfois utilisés alors que **DEBUG** n'est pas activé et que le port Serie n'a pas été initialisé (avec begin).
Cela concerne plus précisement le diagnostique WiFi, le debug en cas d'erreur OTA et l'affichage des entiers en format DEC,HEX etc...
Aussi je propose la création des trois define suivants:
```
#define DebugWiFi() WiFi.printDiag(DEBUG_SERIAL)
#define DebugIntFormat(x,format) DEBUG_SERIAL.print(x, format)
#define DebugUpdateError() Update.printError(DEBUG_SERIAL)
```
